### PR TITLE
adding anonymous field to comments - fixes #45

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -22,11 +22,15 @@ class CommentsController < ApplicationController
   end
 
   def create
+
+    anon = params[:anonymous] ? params[:anonymous].to_bool : false
+
     comment = Comment.new(
       :owner_id => current_user.id,
       :comment => params[:comment].to_s,
       :commentable_type => params[:commentable_type].camelize.singularize,
-      :commentable_id => params[:commentable_id].to_i
+      :commentable_id => params[:commentable_id].to_i,
+      :anonymous => anon
     )
     comment.field = params[:field].to_s if params[:field]
     comment.save!

--- a/config/initializers/string_to_bool.rb
+++ b/config/initializers/string_to_bool.rb
@@ -1,0 +1,9 @@
+#convert a string to a boolean, like ruby should do in the first darn place
+
+class String
+  def to_bool
+    return true   if self == true   || self =~ (/(true|t|yes|y|1)$/i)
+    return false  if self == false  || self.blank? || self =~ (/(false|f|no|n|0)$/i)
+    raise ArgumentError.new("invalid value for Boolean: \"#{self}\"")
+  end
+end

--- a/db/migrate/20140824173025_add_anonymous_to_comments.rb
+++ b/db/migrate/20140824173025_add_anonymous_to_comments.rb
@@ -1,0 +1,5 @@
+class AddAnonymousToComments < ActiveRecord::Migration
+  def change
+    add_column :comments, :anonymous, :boolean
+  end
+end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -90,6 +90,12 @@ describe CommentsController, :type => :controller do
       comment = JSON.parse(response.body)
       comment['owner_id'].should == user.id
     end
+
+    it "should set whether the comment is anonymous when creating a comment" do
+      post :create, :commentable_type => "articles", :commentable_id => article.id, :comment => "my comment"
+      comment = JSON.parse(response.body)
+      comment['anonymous'].should == false
+    end
   end
 
   describe "#destroy" do


### PR DESCRIPTION
This branch:

-runs migration to add anonymous field to comments (bool)
-updates controller and controller_spec to add said field
-adds a file to initializers to allow for string/int-to-boolean conversion via .to_bool (you're welcome)
