### PR TITLE
Update google analytics code

### DIFF
--- a/app/views/beta/index.html.erb
+++ b/app/views/beta/index.html.erb
@@ -10,11 +10,12 @@
     }).install();
 
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-50411070-1', 'curatescience.org');
-    ga('send', 'pageview');
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  ga('create', 'UA-48865749-1', 'auto');
+  ga('send', 'pageview');
+  
   </script>
 <% else %>
   <script type="text/javascript">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,11 +30,12 @@
     }).install();
 
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-50411070-1', 'curatescience.org');
-    ga('send', 'pageview');
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  ga('create', 'UA-48865749-1', 'auto');
+  ga('send', 'pageview');
+  
   </script>
 <% end %>
 </body>


### PR DESCRIPTION
to fix Tracking Code Mismatch issue i just noticed in our Google analytics account, details as follows:

The default URL https://curatescience.org, for property UA-48865749-1 has no tracking code for this property, although it does have tracking codes for other properties:
UA-50411070-1
If your Tracking ID and your Default URL setting are out of sync, you don't get valid data in your Analytics account for the Default URL.

Either update the tracking code to use the Tracking ID for property Curate-Science, or open the Property Settings to update the Default URL for property Curate-Science to be https://curatescience.org.