### PR TITLE
use eager_load to speed up Article queries

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -38,7 +38,7 @@ class ArticlesController < ApplicationController
 
   def recent
     limit = params[:limit] ? params[:limit].to_i : 3
-    render json: Article.order('updated_at DESC')
+    render json: Article.eager_load(:authors, :studies => :links).order('articles.updated_at DESC')
       .paginate(:page => params[:page], :per_page => limit)
       .as_json(:authors => true, methods: [:badges])
   rescue StandardError => ex
@@ -48,7 +48,7 @@ class ArticlesController < ApplicationController
 
   def recently_added
     limit = params[:limit] ? params[:limit].to_i : 3
-    render json: Article.order('created_at DESC')
+    render json: Article.eager_load(:authors, :studies => :links).order('articles.created_at DESC')
       .paginate(:page => params[:page], :per_page => limit)
       .as_json(:authors => true, methods: [:badges])
   rescue StandardError => ex

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -57,11 +57,6 @@ class Article < ActiveRecord::Base
   def as_json(opts={})
     super(opts).tap do |h|
       h['authors'] = self.authors if opts[:authors]
-      last_update = self.last_model_update
-      submitter = if last_update then last_update.submitter else self.owner end
-      update_author = if submitter then submitter.author else nil end
-      h['updated_by_name'] = if submitter then submitter.name else nil end
-      h['updated_by_author_id'] = if update_author then update_author.id else nil end
     end
   end
 


### PR DESCRIPTION
The Article queries for the landing page were essentially nested in a loop (N+1 query problem) and I changed it to use "eager loading" which converts the multiple queries in to a single LEFT OUTER JOIN query. This should cause the landing page to load a lot faster.